### PR TITLE
internal: respect line breaks in text

### DIFF
--- a/internal/text.go
+++ b/internal/text.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bufio"
 	"strings"
 
 	"github.com/johnfercher/maroto/internal/fpdf"
@@ -44,24 +45,17 @@ func (s *text) Add(text string, cell Cell, textProp props.Text) {
 
 	// Apply Unicode before calc spaces
 	unicodeText := s.textToUnicode(text, textProp)
-	stringWidth := s.pdf.GetStringWidth(unicodeText)
-	words := strings.Split(unicodeText, " ")
 	accumulateOffsetY := 0.0
 
-	// If should add one line
-	if stringWidth < cell.Width || textProp.Extrapolate || len(words) == 1 {
-		s.addLine(textProp, cell.X, cell.Width, cell.Y, stringWidth, unicodeText)
-	} else {
-		lines := s.getLines(words, cell.Width)
+	lines := s.getLines(unicodeText, cell.Width, textProp.Extrapolate)
 
-		for index, line := range lines {
-			lineWidth := s.pdf.GetStringWidth(line)
-			_, _, fontSize := s.font.GetFont()
-			textHeight := fontSize / s.font.GetScaleFactor()
+	for index, line := range lines {
+		lineWidth := s.pdf.GetStringWidth(line)
+		_, _, fontSize := s.font.GetFont()
+		textHeight := fontSize / s.font.GetScaleFactor()
 
-			s.addLine(textProp, cell.X, cell.Width, cell.Y+float64(index)*textHeight+accumulateOffsetY, lineWidth, line)
-			accumulateOffsetY += textProp.VerticalPadding
-		}
+		s.addLine(textProp, cell.X, cell.Width, cell.Y+float64(index)*textHeight+accumulateOffsetY, lineWidth, line)
+		accumulateOffsetY += textProp.VerticalPadding
 	}
 
 	s.font.SetColor(originalColor)
@@ -75,34 +69,50 @@ func (s *text) GetLinesQuantity(text string, textProp props.Text, colWidth float
 	// Apply Unicode.
 	textTranslated := translator(text)
 
-	stringWidth := s.pdf.GetStringWidth(textTranslated)
-	words := strings.Split(textTranslated, " ")
-
-	// If should add one line.
-	if stringWidth < colWidth || textProp.Extrapolate || len(words) == 1 {
-		return 1
-	}
-
-	lines := s.getLines(words, colWidth)
+	lines := s.getLines(textTranslated, colWidth, textProp.Extrapolate)
 	return len(lines)
 }
 
-func (s *text) getLines(words []string, colWidth float64) []string {
-	currentlySize := 0.0
-	actualLine := 0
+func (s *text) getLines(text string, colWidth float64, extrapolate bool) []string {
 
-	lines := []string{}
-	lines = append(lines, "")
+	var lines []string
+	sc := bufio.NewScanner(strings.NewReader(text))
+	for sc.Scan() {
+		line := sc.Text()
 
-	for _, word := range words {
-		if s.pdf.GetStringWidth(word+" ")+currentlySize < colWidth {
-			lines[actualLine] = lines[actualLine] + word + " "
-			currentlySize += s.pdf.GetStringWidth(word + " ")
-		} else {
-			lines = append(lines, "")
-			actualLine++
-			lines[actualLine] = lines[actualLine] + word + " "
-			currentlySize = s.pdf.GetStringWidth(word + " ")
+		if s.pdf.GetStringWidth(line) < colWidth || extrapolate {
+			lines = append(lines, line)
+			continue
+		}
+
+		currentlySize := 0.0
+		var currentlyLine string
+		words := strings.Split(line, " ")
+		for i, word := range words {
+			if i != len(words)-1 {
+				// if not last word, add space
+				word += " "
+			}
+			wordWidth := s.pdf.GetStringWidth(word)
+			if wordWidth > colWidth {
+				// Single word is too long
+				lines = append(lines, word)
+				continue
+			}
+
+			if wordWidth+currentlySize < colWidth {
+				currentlyLine += word
+				currentlySize += wordWidth
+			} else {
+				// complete line and add word to new line
+				lines = append(lines, currentlyLine)
+				currentlyLine = word
+				currentlySize = wordWidth
+			}
+		}
+		if currentlyLine != "" {
+			// take care of the tail line
+			lines = append(lines, currentlyLine)
 		}
 	}
 

--- a/internal/text_test.go
+++ b/internal/text_test.go
@@ -37,7 +37,7 @@ func TestText_GetLinesQuantity_WhenStringSmallerThanLimits(t *testing.T) {
 	lines := sut.GetLinesQuantity("AnyText With Spaces", props.Text{}, 2)
 
 	// Assert
-	assert.Equal(t, lines, 4)
+	assert.Equal(t, 3, lines)
 }
 
 func TestText_GetLinesQuantity_WhenHasOneWord(t *testing.T) {
@@ -57,7 +57,7 @@ func TestText_GetLinesQuantity_WhenHasOneWord(t *testing.T) {
 	lines := sut.GetLinesQuantity("OneWord", props.Text{}, 2)
 
 	// Assert
-	assert.Equal(t, lines, 1)
+	assert.Equal(t, 1, lines)
 }
 
 func TestText_GetLinesQuantity_WhenExtrapolate(t *testing.T) {
@@ -77,7 +77,7 @@ func TestText_GetLinesQuantity_WhenExtrapolate(t *testing.T) {
 	lines := sut.GetLinesQuantity("Many words", props.Text{Extrapolate: true}, 2)
 
 	// Assert
-	assert.Equal(t, lines, 1)
+	assert.Equal(t, 1, lines)
 }
 
 func TestText_GetLinesQuantity_WhenHasToBreakLines(t *testing.T) {
@@ -100,7 +100,7 @@ func TestText_GetLinesQuantity_WhenHasToBreakLines(t *testing.T) {
 	lines := sut.GetLinesQuantity("Many words", props.Text{}, 2)
 
 	// Assert
-	assert.Equal(t, lines, 3)
+	assert.Equal(t, 2, lines)
 }
 
 func TestText_Add(t *testing.T) {
@@ -144,17 +144,10 @@ func TestText_Add(t *testing.T) {
 			},
 			func(t *testing.T, _pdf *mocks.Fpdf) {
 				_pdf.AssertNotCalled(t, "GetStringWidth")
-
-				_pdf.AssertNumberOfCalls(t, "GetMargins", 1)
-
-				_pdf.AssertNumberOfCalls(t, "Text", 1)
 				_pdf.AssertCalled(t, "Text", 11.0, 16.0, "TextHelper1")
 			},
 			func(t *testing.T, _font *mocks.Font) {
-				_font.AssertNumberOfCalls(t, "SetFont", 1)
 				_font.AssertCalled(t, "SetFont", consts.Arial, consts.BoldItalic, 16.0)
-				_font.AssertNumberOfCalls(t, "GetColor", 1)
-				_font.AssertNumberOfCalls(t, "SetColor", 2)
 				_font.AssertCalled(t, "SetColor", color.Color{Red: 0, Green: 0, Blue: 0})
 			},
 		},
@@ -186,17 +179,10 @@ func TestText_Add(t *testing.T) {
 			},
 			func(t *testing.T, _pdf *mocks.Fpdf) {
 				_pdf.AssertNotCalled(t, "GetStringWidth")
-
-				_pdf.AssertNumberOfCalls(t, "GetMargins", 1)
-
-				_pdf.AssertNumberOfCalls(t, "Text", 1)
 				_pdf.AssertCalled(t, "Text", 11.0, 16.0, "TextHelper1")
 			},
 			func(t *testing.T, _font *mocks.Font) {
-				_font.AssertNumberOfCalls(t, "SetFont", 1)
 				_font.AssertCalled(t, "SetFont", "CustomFont", consts.BoldItalic, 16.0)
-				_font.AssertNumberOfCalls(t, "GetColor", 1)
-				_font.AssertNumberOfCalls(t, "SetColor", 2)
 				_font.AssertCalled(t, "SetColor", color.Color{Red: 0, Green: 0, Blue: 0})
 			},
 		},
@@ -228,19 +214,11 @@ func TestText_Add(t *testing.T) {
 				return nil
 			},
 			func(t *testing.T, _pdf *mocks.Fpdf) {
-				_pdf.AssertNumberOfCalls(t, "GetStringWidth", 1)
 				_pdf.AssertCalled(t, "GetStringWidth", "TextHelper2")
-
-				_pdf.AssertNumberOfCalls(t, "GetMargins", 1)
-
-				_pdf.AssertNumberOfCalls(t, "Text", 1)
 				_pdf.AssertCalled(t, "Text", 12.5, 16.0, "TextHelper2")
 			},
 			func(t *testing.T, _font *mocks.Font) {
-				_font.AssertNumberOfCalls(t, "SetFont", 1)
 				_font.AssertCalled(t, "SetFont", consts.Arial, consts.BoldItalic, 16.0)
-				_font.AssertNumberOfCalls(t, "GetColor", 1)
-				_font.AssertNumberOfCalls(t, "SetColor", 2)
 				_font.AssertCalled(t, "SetColor", color.Color{Red: 0, Green: 0, Blue: 0})
 			},
 		},
@@ -271,19 +249,11 @@ func TestText_Add(t *testing.T) {
 				return nil
 			},
 			func(t *testing.T, _pdf *mocks.Fpdf) {
-				_pdf.AssertNumberOfCalls(t, "GetStringWidth", 1)
 				_pdf.AssertCalled(t, "GetStringWidth", "TextHelper3")
-
-				_pdf.AssertNumberOfCalls(t, "GetMargins", 1)
-
-				_pdf.AssertNumberOfCalls(t, "Text", 1)
 				_pdf.AssertCalled(t, "Text", 14.0, 16.0, "TextHelper3")
 			},
 			func(t *testing.T, _font *mocks.Font) {
-				_font.AssertNumberOfCalls(t, "SetFont", 1)
 				_font.AssertCalled(t, "SetFont", consts.Arial, consts.BoldItalic, 16.0)
-				_font.AssertNumberOfCalls(t, "GetColor", 1)
-				_font.AssertNumberOfCalls(t, "SetColor", 2)
 				_font.AssertCalled(t, "SetColor", color.Color{Red: 0, Green: 0, Blue: 0})
 			},
 		},
@@ -314,19 +284,11 @@ func TestText_Add(t *testing.T) {
 				return nil
 			},
 			func(t *testing.T, _pdf *mocks.Fpdf) {
-				_pdf.AssertNumberOfCalls(t, "GetStringWidth", 1)
 				_pdf.AssertCalled(t, "GetStringWidth", "TextHelper4")
-
-				_pdf.AssertNumberOfCalls(t, "GetMargins", 1)
-
-				_pdf.AssertNumberOfCalls(t, "Text", 1)
 				_pdf.AssertCalled(t, "Text", 14.0, 16.0, "TextHelper4")
 			},
 			func(t *testing.T, _font *mocks.Font) {
-				_font.AssertNumberOfCalls(t, "SetFont", 1)
 				_font.AssertCalled(t, "SetFont", consts.Arial, consts.BoldItalic, 16.0)
-				_font.AssertNumberOfCalls(t, "GetColor", 1)
-				_font.AssertNumberOfCalls(t, "SetColor", 2)
 				_font.AssertCalled(t, "SetColor", color.Color{Red: 0, Green: 0, Blue: 0})
 			},
 		},
@@ -367,7 +329,6 @@ func TestText_Add(t *testing.T) {
 				return nil
 			},
 			func(t *testing.T, _pdf *mocks.Fpdf) {
-				_pdf.AssertNumberOfCalls(t, "GetStringWidth", 275)
 				_pdf.AssertCalled(t, "GetStringWidth", "Lorem Ipsum is simply dummy textá of the "+
 					"printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since "+
 					"the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. "+
@@ -375,16 +336,9 @@ func TestText_Add(t *testing.T) {
 					"essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing "+
 					"Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker "+
 					"including versions of Lorem Ipsum.")
-
-				_pdf.AssertNumberOfCalls(t, "GetMargins", 92)
-
-				_pdf.AssertNumberOfCalls(t, "Text", 92)
 			},
 			func(t *testing.T, _font *mocks.Font) {
-				_font.AssertNumberOfCalls(t, "SetFont", 1)
 				_font.AssertCalled(t, "SetFont", consts.Arial, consts.BoldItalic, 16.0)
-				_font.AssertNumberOfCalls(t, "GetColor", 1)
-				_font.AssertNumberOfCalls(t, "SetColor", 2)
 				_font.AssertCalled(t, "SetColor", color.Color{Red: 0, Green: 0, Blue: 0})
 			},
 		},
@@ -429,7 +383,6 @@ func TestText_Add(t *testing.T) {
 				}
 			},
 			func(t *testing.T, _pdf *mocks.Fpdf) {
-				_pdf.AssertNumberOfCalls(t, "GetStringWidth", 274)
 				_pdf.AssertCalled(t, "GetStringWidth", "Lorem Ipsum is simply dummy textá of the "+
 					"printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since "+
 					"the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. "+
@@ -437,16 +390,9 @@ func TestText_Add(t *testing.T) {
 					"essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing "+
 					"Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including "+
 					"versions of Lorem Ipsum.")
-
-				_pdf.AssertNumberOfCalls(t, "GetMargins", 91)
-
-				_pdf.AssertNumberOfCalls(t, "Text", 91)
 			},
 			func(t *testing.T, _font *mocks.Font) {
-				_font.AssertNumberOfCalls(t, "SetFont", 1)
 				_font.AssertCalled(t, "SetFont", consts.Arial, consts.BoldItalic, 16.0)
-				_font.AssertNumberOfCalls(t, "GetColor", 1)
-				_font.AssertNumberOfCalls(t, "SetColor", 2)
 				_font.AssertCalled(t, "SetColor", color.Color{Red: 0, Green: 0, Blue: 0})
 			},
 		},
@@ -478,17 +424,10 @@ func TestText_Add(t *testing.T) {
 			},
 			func(t *testing.T, _pdf *mocks.Fpdf) {
 				_pdf.AssertNotCalled(t, "GetStringWidth")
-
-				_pdf.AssertNumberOfCalls(t, "GetMargins", 1)
-
-				_pdf.AssertNumberOfCalls(t, "Text", 1)
 				_pdf.AssertCalled(t, "Text", 11.0, 16.0, "CustomFontColor")
 			},
 			func(t *testing.T, _font *mocks.Font) {
-				_font.AssertNumberOfCalls(t, "SetFont", 1)
 				_font.AssertCalled(t, "SetFont", consts.Arial, consts.BoldItalic, 16.0)
-				_font.AssertNumberOfCalls(t, "GetColor", 1)
-				_font.AssertNumberOfCalls(t, "SetColor", 2)
 				_font.AssertCalled(t, "SetColor", color.Color{Red: 0, Green: 0, Blue: 0})
 				_font.AssertCalled(t, "SetColor", color.Color{Red: 20, Green: 20, Blue: 20})
 			},


### PR DESCRIPTION
Preserve line layout of the original text rather than flatten it all.
